### PR TITLE
Add: support Proxy Protocol v1 (if requested)

### DIFF
--- a/bananas_server/__main__.py
+++ b/bananas_server/__main__.py
@@ -17,6 +17,7 @@ from .index.local import click_index_local
 from .storage.local import click_storage_local
 from .storage.s3 import click_storage_s3
 from .openttd import tcp_content
+from .openttd.tcp_content import click_proxy_protocol
 
 log = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ def click_logging():
 @click_index_github
 @web_routes.click_web_routes
 @click.option("--validate", help="Only validate BaNaNaS files and exit", is_flag=True)
+@click_proxy_protocol
 def main(bind, content_port, web_port, storage, index, validate):
     app_instance = Application(storage(), index())
 

--- a/bananas_server/openttd/tcp_content.py
+++ b/bananas_server/openttd/tcp_content.py
@@ -1,22 +1,26 @@
 import asyncio
+import click
 import logging
 
 from .protocol.exceptions import PacketInvalid
 from .protocol.source import Source
 from .receive import OpenTTDProtocolReceive
 from .send import OpenTTDProtocolSend
+from ..helpers.click import click_additional_options
 
 log = logging.getLogger(__name__)
 
 
 class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTTDProtocolSend):
+    proxy_protocol = False
+
     def __init__(self, callback_class):
         super().__init__()
         self._callback = callback_class
         self._callback.protocol = self
         self._queue = asyncio.Queue()
         self._data = b""
-        self.is_ipv6 = None
+        self.new_connection = True
 
         asyncio.create_task(self._process_queue())
 
@@ -24,16 +28,35 @@ class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTT
         self.transport = transport
         socket_addr = transport.get_extra_info("peername")
         self.source = Source(self, socket_addr, socket_addr[0], socket_addr[1])
-        # TODO -- Support PROXY protocol
 
-        # In Python, a socket is a tuple of 4 when it is IPv6,
-        # and a tuple of 2 if it is IPv4.
-        if len(transport.get_extra_info("sockname")) == 4:
-            self.is_ipv6 = True
-        else:
-            self.is_ipv6 = False
+    def _detect_source_ip_port(self, data):
+        if not self.proxy_protocol:
+            return data
+
+        # If enabled, expect new connections to start with PROXY. In this
+        # header is the original source of the connection.
+        if data[0:5] != b"PROXY":
+            log.warning("Receive data without a proxy protocol header from %s:%d", self.source.ip, self.source.port)
+            return data
+
+        # This message arrived via the proxy protocol; use the information
+        # from this to figure out the real ip and port.
+        proxy_end = data.find(b"\r\n")
+        proxy = data[0:proxy_end].decode()
+        data = data[proxy_end + 2 :]
+
+        # Example how 'proxy' looks:
+        #  PROXY TCP4 127.0.0.1 127.0.0.1 33487 12345
+
+        (_, _, ip, _, port, _) = proxy.split(" ")
+        self.source = Source(self, self.source.addr, ip, int(port))
+        return data
 
     def data_received(self, data):
+        if self.new_connection:
+            data = self._detect_source_ip_port(data)
+            self.new_connection = False
+
         self._data = self.receive_data(self._queue, self._data + data)
 
     async def _process_queue(self):
@@ -43,7 +66,7 @@ class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTT
             try:
                 type, kwargs = self.receive_packet(self.source, data)
             except PacketInvalid as err:
-                log.info("Dropping invalid packet from %r: %r", self.source.addr, err)
+                log.info("Dropping invalid packet from %s:%d: %r", self.source.ip, self.source.port, err)
                 self.transport.close()
                 return
 
@@ -55,3 +78,13 @@ class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTT
 
     def send_packet(self, data):
         self.transport.write(data)
+
+
+@click_additional_options
+@click.option(
+    "--proxy-protocol",
+    help="Enable Proxy Protocol (v1), and expect all incoming package to have this header.",
+    is_flag=True,
+)
+def click_proxy_protocol(proxy_protocol):
+    OpenTTDProtocolTCPContent.proxy_protocol = proxy_protocol


### PR DESCRIPTION
You should ever only enable this setting if you control all
incoming connections to this application. If you make this
directly internet facing, there is a chance people will abuse
the proxy protocol to fake their location. Use with caution!