### PR TITLE
Fix: stop sending data if the other end closed the connection

### DIFF
--- a/bananas_server/openttd/send.py
+++ b/bananas_server/openttd/send.py
@@ -74,7 +74,8 @@ class OpenTTDProtocolSend:
             data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_CONTENT)
             data += stream.read(SEND_MTU - 3)
             data = write_presend(data)
-            self.send_packet(data)
+            if not self.send_packet(data):
+                return
 
         data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_CONTENT)
         data = write_presend(data)

--- a/bananas_server/openttd/tcp_content.py
+++ b/bananas_server/openttd/tcp_content.py
@@ -81,6 +81,11 @@ class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTT
 
     def send_packet(self, data):
         self.transport.write(data)
+        # When a socket is closed on the other side, and due to the nature of
+        # how asyncio is doing writes, we never receive an exception. So,
+        # instead, check every time we send something if we are not closed.
+        # If we are, inform our caller which should stop transmitting.
+        return not self.transport.is_closing()
 
 
 @click_additional_options


### PR DESCRIPTION
This is only a problem if we are sending a lot of data to the
client, like a binary. So check after every transmit if the
connection was closed, and stop sending if it was.