### PR TITLE
Fix #17: postfix the filename as it should be on disk to the redirect URL

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -2,6 +2,7 @@ import logging
 
 from collections import defaultdict
 
+from ..helpers.safe_filename import safe_filename
 from ..openttd.protocol.enums import ContentType
 
 log = logging.getLogger(__name__)
@@ -39,25 +40,6 @@ class Application:
             dependencies=content_entry.dependencies,
             tags=content_entry.tags,
         )
-
-    def _safe_name(self, name):
-        new_name = ""
-
-        for letter in name:
-            if (
-                (letter >= "a" and letter <= "z")
-                or (letter >= "A" and letter <= "Z")
-                or (letter >= "0" and letter <= "9")
-                or letter == "."
-            ):
-                new_name += letter
-            elif new_name and new_name[-1] != "_":
-                new_name += "_"
-
-        return new_name.strip("._")
-
-    def _safe_filename(self, name, version):
-        return self._safe_name(name) + "-" + self._safe_name(version)
 
     def get_by_content_id(self, content_id):
         return self._by_content_id.get(content_id)
@@ -118,7 +100,7 @@ class Application:
                 content_type=content_entry.content_type,
                 content_id=content_entry.content_id,
                 filesize=content_entry.filesize,
-                filename=self._safe_filename(content_entry.name, content_entry.version),
+                filename=safe_filename(content_entry.name, content_entry.version),
                 stream=stream,
             )
 

--- a/bananas_server/helpers/safe_filename.py
+++ b/bananas_server/helpers/safe_filename.py
@@ -1,0 +1,19 @@
+def _safe_name(name):
+    new_name = ""
+
+    for letter in name:
+        if (
+            (letter >= "a" and letter <= "z")
+            or (letter >= "A" and letter <= "Z")
+            or (letter >= "0" and letter <= "9")
+            or letter == "."
+        ):
+            new_name += letter
+        elif new_name and new_name[-1] != "_":
+            new_name += "_"
+
+    return new_name.strip("._")
+
+
+def safe_filename(name, version):
+    return _safe_name(name) + "-" + _safe_name(version)

--- a/bananas_server/web_routes.py
+++ b/bananas_server/web_routes.py
@@ -5,6 +5,7 @@ from aiohttp import web
 
 from .helpers.click import click_additional_options
 from .helpers.content_type import get_folder_name_from_content_type
+from .helpers.safe_filename import safe_filename
 
 log = logging.getLogger(__name__)
 routes = web.RouteTableDef()
@@ -37,11 +38,12 @@ async def balancer_handler(request):
             continue
 
         folder_name = get_folder_name_from_content_type(content_entry.content_type)
+        safe_name = safe_filename(content_entry.name, content_entry.version)
         response += (
             f"{content_id},"
             f"{content_entry.content_type.value},"
             f"{content_entry.filesize},"
-            f"{CDN_URL}/{folder_name}/{content_entry.unique_id.hex()}/{content_entry.md5sum.hex()}.tar.gz"
+            f"{CDN_URL}/{folder_name}/{content_entry.unique_id.hex()}/{content_entry.md5sum.hex()}/{safe_name}.tar.gz"
             f"\n"
         )
 


### PR DESCRIPTION
This means the client stores the file under that name instead of
the md5sum. The infrastructure handles this redirect to the real
file.