### PR TITLE
Fix #56: make sure filenames send to the client are unique

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -100,7 +100,7 @@ class Application:
                 content_type=content_entry.content_type,
                 content_id=content_entry.content_id,
                 filesize=content_entry.filesize,
-                filename=safe_filename(content_entry.name, content_entry.version),
+                filename=safe_filename(content_entry),
                 stream=stream,
             )
 

--- a/bananas_server/helpers/safe_filename.py
+++ b/bananas_server/helpers/safe_filename.py
@@ -15,5 +15,7 @@ def _safe_name(name):
     return new_name.strip("._")
 
 
-def safe_filename(name, version):
-    return _safe_name(name) + "-" + _safe_name(version)
+def safe_filename(content_entry):
+    return (
+        content_entry.unique_id.hex() + "-" + _safe_name(content_entry.name) + "-" + _safe_name(content_entry.version)
+    )

--- a/bananas_server/web_routes.py
+++ b/bananas_server/web_routes.py
@@ -38,7 +38,7 @@ async def balancer_handler(request):
             continue
 
         folder_name = get_folder_name_from_content_type(content_entry.content_type)
-        safe_name = safe_filename(content_entry.name, content_entry.version)
+        safe_name = safe_filename(content_entry)
         response += (
             f"{content_id},"
             f"{content_entry.content_type.value},"


### PR DESCRIPTION
The name of a package doesn't have to be unique. The unique-id
and the version does. So use at least those two to make sure
filenames are unique.