### PR TITLE
Add: only buffer at most 5 max-sized packets per client

### DIFF
--- a/bananas_server/openttd/protocol/exceptions.py
+++ b/bananas_server/openttd/protocol/exceptions.py
@@ -16,3 +16,7 @@ class PacketInvalidData(PacketInvalid):
 
 class PacketTooBig(PacketInvalid):
     """The packet is too big to transmit."""
+
+
+class SocketClosed(Exception):
+    """The socket was closed by the other side."""

--- a/bananas_server/openttd/send.py
+++ b/bananas_server/openttd/send.py
@@ -15,7 +15,7 @@ from .protocol.write import (
 
 
 class OpenTTDProtocolSend:
-    def send_PACKET_CONTENT_SERVER_INFO(
+    async def send_PACKET_CONTENT_SERVER_INFO(
         self, content_type, content_id, filesize, name, version, url, description, unique_id, md5sum, dependencies, tags
     ):
         data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_INFO)
@@ -54,9 +54,9 @@ class OpenTTDProtocolSend:
             data = write_string(data, tag)
 
         data = write_presend(data)
-        self.send_packet(data)
+        await self.send_packet(data)
 
-    def send_PACKET_CONTENT_SERVER_CONTENT(self, content_type, content_id, filesize, filename, stream):
+    async def send_PACKET_CONTENT_SERVER_CONTENT(self, content_type, content_id, filesize, filename, stream):
         # First, send a packet to tell the client it will be receiving a file
         data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_CONTENT)
 
@@ -67,16 +67,15 @@ class OpenTTDProtocolSend:
         data = write_string(data, filename)
 
         data = write_presend(data)
-        self.send_packet(data)
+        await self.send_packet(data)
 
         # Next, send the content of the file over
         while not stream.eof():
             data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_CONTENT)
             data += stream.read(SEND_MTU - 3)
             data = write_presend(data)
-            if not self.send_packet(data):
-                return
+            await self.send_packet(data)
 
         data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_CONTENT)
         data = write_presend(data)
-        self.send_packet(data)
+        await self.send_packet(data)


### PR DESCRIPTION
This means that when a user downloads a 500+ MiB content entry,
and is on a slow connection, the asyncio write() task will no
longer cache this in full in the memory. Now it will "async" out
till there is room in the write buffer again before continueing
to write. This should heavily reduce the memory footprint in
production.

Additionally, raise an exception if the socket is being closed,
instead of returning False. This means it bubbles up for all
send_packet() calls, which should reduce the amount of warnings
we are now seeing about writing to a closed socket.

Also fixes https://github.com/OpenTTD/bananas-server/issues/15