### PR TITLE
Add: reload the database in a separate process

### DIFF
--- a/bananas_server/index/github.py
+++ b/bananas_server/index/github.py
@@ -82,7 +82,7 @@ class Index(LocalIndex):
 
     def reload(self, application):
         self._fetch_latest()
-        super().reload(application)
+        return super().reload(application)
 
 
 @click_additional_options

--- a/bananas_server/web_routes.py
+++ b/bananas_server/web_routes.py
@@ -63,7 +63,7 @@ async def reload(request):
     if data["secret"] != RELOAD_SECRET:
         return web.HTTPNotFound()
 
-    BANANAS_SERVER_APPLICATION.reload()
+    await BANANAS_SERVER_APPLICATION.reload()
 
     return web.HTTPNoContent()
 


### PR DESCRIPTION
This means that during reloads, the server is fully responsive
with the old code. Once the reload is done, the database is
swapped around in memory, and any changes will be available from
that point on.

There was need for some rewrite, as the less is sent over the
wire during process creation, the better. This should now be
brought to a minimum: things like configuration and that is it.
This has one downside, that for a time there are two full
dictionaries are in memory. This increases the memory footprint
of the application a bit; in return we get a non-blocking reload.