### PR TITLE
Add: an option to indicate the first entry in BaseGraphics listing

### DIFF
--- a/bananas_server/__main__.py
+++ b/bananas_server/__main__.py
@@ -78,10 +78,14 @@ def click_logging():
 @click_index_local
 @click_index_github
 @web_routes.click_web_routes
+@click.option(
+    "--bootstrap-unique-id",
+    help="Unique-id of the content entry to use as Base Graphic during OpenTTD client's bootstrap",
+)
 @click.option("--validate", help="Only validate BaNaNaS files and exit", is_flag=True)
 @click_proxy_protocol
-def main(bind, content_port, web_port, storage, index, validate):
-    app_instance = Application(storage(), index())
+def main(bind, content_port, web_port, storage, index, bootstrap_unique_id, validate):
+    app_instance = Application(storage(), index(), bootstrap_unique_id)
 
     if validate:
         return


### PR DESCRIPTION
OpenTTD client's bootstrap implementation downloads what-ever is
the first entry of the BaseGraphics listing. Without this, this
strongly depends on the order of listdir(), but rarely is OpenGFX,
which we prefer. Of course this can be considered a bug in OpenTTD
client, but for now we can fix this by adding an option that forces
a predefined unique-id to be the first in the list. In production
this will of course be OpenGFX.