### PR TITLE
Fix: don't report SocketClosed when sending

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -130,6 +130,10 @@ class Application:
                 # Reading from the backend failed; we don't have many options
                 # except to abort the connection and hope the user retries.
                 raise SocketClosed
+            except SocketClosed:
+                # The user terminated it's connection; our caller knows how to
+                # handle this signal.
+                raise
             except Exception:
                 log.exception("Error with storage, aborting for this client ...")
                 raise SocketClosed


### PR DESCRIPTION
SocketClosed happens when the other side closed the connection,
and is pretty common in production. The caller knows how to handle
this signal just fine, so pass it through.