### PR TITLE
Add: support client connections over WebSocket / HTTP

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -18,7 +18,6 @@ class Application:
 
         self.storage = storage
         self.index = index
-        self.protocol = None
 
         if bootstrap_unique_id:
             self._bootstrap_unique_id = bytes.fromhex(bootstrap_unique_id)

--- a/bananas_server/openttd/tcp_content.py
+++ b/bananas_server/openttd/tcp_content.py
@@ -2,6 +2,7 @@ import asyncio
 import click
 import logging
 
+from asyncio.coroutines import iscoroutine
 from openttd_helpers import click_helper
 
 from .protocol.exceptions import (
@@ -22,7 +23,6 @@ class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTT
     def __init__(self, callback_class):
         super().__init__()
         self._callback = callback_class
-        self._callback.protocol = self
         self._queue = asyncio.Queue()
         self._data = b""
         self.new_connection = True
@@ -132,7 +132,9 @@ class OpenTTDProtocolTCPContent(asyncio.Protocol, OpenTTDProtocolReceive, OpenTT
         if self.transport.is_closing():
             raise SocketClosed
 
-        self.transport.write(data)
+        res = self.transport.write(data)
+        if iscoroutine(res):
+            await res
 
 
 @click_helper.extend


### PR DESCRIPTION
If on the / URL it is detected that this is in fact a WebSocket,
it will be upgraded and act like a TCP connection. The protocol
is expected to be "binary", and the exact same OpenTTD protocol
is used as with the TCP connection to the server.