### PR TITLE
Add: pass upload date to OpenTTD client

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -48,6 +48,7 @@ class Application:
             md5sum=content_entry.md5sum,
             dependencies=content_entry.dependencies,
             tags=content_entry.tags,
+            upload_date=content_entry.upload_date,
         )
 
     def get_by_content_id(self, content_id):

--- a/bananas_server/index/local.py
+++ b/bananas_server/index/local.py
@@ -95,6 +95,8 @@ class Index:
         md5sum_partial = bytes.fromhex(data["md5sum-partial"])
         md5sum = md5sum_mapping[content_type][unique_id][md5sum_partial]
 
+        upload_date = int(data["upload-date"].timestamp())
+
         dependencies = []
         for dependency in data.get("dependencies", []):
             dep_content_type = get_content_type_from_name(dependency["content-type"])
@@ -130,6 +132,7 @@ class Index:
                 "url": data.get("url", ""),
                 "description": data.get("description", ""),
                 "unique-id": unique_id,
+                "upload-date": upload_date,
                 "md5sum": md5sum,
                 "min-version": min_version,
                 "max-version": max_version,
@@ -151,6 +154,7 @@ class Index:
         size += 1
         for tag in data.get("tags", []):
             size += len(tag) + 2
+        size += 4  # upload_date
 
         if size > 1400:
             raise Exception("Entry would exceed OpenTTD packet size.")

--- a/bananas_server/index/schema.py
+++ b/bananas_server/index/schema.py
@@ -23,6 +23,7 @@ class ContentEntry(Schema):
     description = fields.String(validate=validate.Length(max=511))
     tags = fields.List(fields.String(validate=validate.Length(max=31)))
     md5sum = fields.Raw(validate=validate.Length(min=16, max=16))
+    upload_date = fields.Integer(data_key="upload-date")
     min_version = fields.List(fields.Integer(), data_key="min-version", missing=None)
     max_version = fields.List(fields.Integer(), data_key="max-version", missing=None)
     raw_dependencies = fields.List(

--- a/bananas_server/openttd/send.py
+++ b/bananas_server/openttd/send.py
@@ -16,7 +16,19 @@ from .protocol.write import (
 
 class OpenTTDProtocolSend:
     async def send_PACKET_CONTENT_SERVER_INFO(
-        self, content_type, content_id, filesize, name, version, url, description, unique_id, md5sum, dependencies, tags
+        self,
+        content_type,
+        content_id,
+        filesize,
+        name,
+        version,
+        url,
+        description,
+        unique_id,
+        md5sum,
+        dependencies,
+        tags,
+        upload_date,
     ):
         data = write_init(PacketTCPContentType.PACKET_CONTENT_SERVER_INFO)
 
@@ -52,6 +64,8 @@ class OpenTTDProtocolSend:
         data = write_uint8(data, len(tags))
         for tag in tags:
             data = write_string(data, tag)
+
+        data = write_uint32(data, int(upload_date.timestamp()))
 
         data = write_presend(data)
         await self.send_packet(data)


### PR DESCRIPTION
Implementing logic to pass the "upload-date" field to OpenTTD so we could explore the ability of displaying it in the NewGRF window as well as sorting by upload date in the client as well.

I have tested it by making the corresponding changes in OpenTTD to receive the value, and here it is:

![image](https://user-images.githubusercontent.com/2025406/112797733-ae25d400-9020-11eb-85b9-15dfb1da4914.png)

In particular, I've focused on making sure this doesn't break older versions. Here is what I have successfully tested:

1. Bananas returning the new field, OpenTTD not knowing about it -> OpenTTD ignores it as it has read the latest field it knows about it (tags) and moves on to the next NewGRF. No memory leak or anything out of normal.
2. Bananas returning the new field, OpenTTD knowing about it -> OpenTTD reads it successfully.
3. Bananas not returning the new field, OpenTTD expecting it -> OpenTTD tries to read it but does not actually read it. I used CanReadFromPacket() to verify and make it safe in case we have to rollback Bananas and newer OpenTTD clients still want the value.