### PR TITLE
Change: also allow "official" as compatibility entry

### DIFF
--- a/bananas_server/index/local.py
+++ b/bananas_server/index/local.py
@@ -108,7 +108,7 @@ class Index:
         min_version = None
         max_version = None
         for com in data.get("compatibility", {}):
-            if com["name"] != "master":
+            if com["name"] not in ("master", "official"):
                 continue
 
             for conditions in com["conditions"]:


### PR DESCRIPTION
This commit allows us to deploy this, and rename the entries in the storage. After that is done, we can remove the old entry.