### PR TITLE
Fix: setting up a websocket connection causes an exception

### DIFF
--- a/bananas_server/web_routes.py
+++ b/bananas_server/web_routes.py
@@ -44,7 +44,7 @@ class WebsocketTransport:
 
         return self._source
 
-    def set_write_buffer_limits(self, hard_limit, soft_limit):
+    def set_write_buffer_limits(self, hard_limit=None, soft_limit=None):
         pass
 
 


### PR DESCRIPTION
The Transport interface was implemented wrongly, as "hard_limit"
and "soft_limit" are optional in the Transport interface.