### PR TITLE
Fix: crash with invalid version for a branch with CLIENT_INFO_LIST

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -85,6 +85,12 @@ class Application:
             versions = {}
 
             for branch, version in branch_versions.items():
+                if not all([p.isnumeric() for p in version.split(".")]):
+                    log.warning(
+                        "CLIENT_INFO_LIST version-parts for branch '%s' contains non-integers: %s", branch, version
+                    )
+                    return
+
                 versions[branch] = [int(p) for p in version.split(".")]
 
         bootstrap_content_entry = None


### PR DESCRIPTION
There is a choice to make:
1) parse as much of the version as possible
2) ignore the branch
3) ignore the request

This commit goes for 3), as that is the most verbose to the developer
working on OpenTTD. It is a protocol violation, and the developer
should address the issue. With 1) and 2) it could remain invisible
for a very long time, till it breaks. 3) is the safest, as it
will be noticed sooner or later.