### PR TITLE
Feature: use classification as tags

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -37,6 +37,17 @@ class Application:
         loop.run_until_complete(self.reload())
 
     async def _send_content_entry(self, source, content_entry):
+        # For backwards compatibility, we send classifications as tags.
+        tags = []
+        for key, value in content_entry.classification.items():
+            if type(value) == str:
+                tags.append(value)
+            elif type(value) == bool:
+                if value:
+                    tags.append(key)
+            else:
+                log.error(f"Unknown type for tag {key}: {type(value)}")
+
         await source.protocol.send_PACKET_CONTENT_SERVER_INFO(
             content_type=content_entry.content_type,
             content_id=content_entry.content_id,
@@ -48,7 +59,7 @@ class Application:
             unique_id=content_entry.unique_id,
             md5sum=content_entry.md5sum,
             dependencies=content_entry.dependencies,
-            tags=content_entry.tags,
+            tags=tags,
         )
 
     def get_by_content_id(self, content_id):

--- a/bananas_server/index/local.py
+++ b/bananas_server/index/local.py
@@ -31,7 +31,7 @@ class ContentEntry:
         md5sum,
         dependencies,
         compatibility,
-        tags,
+        classification,
     ):
         super().__init__()
 
@@ -48,7 +48,7 @@ class ContentEntry:
         self.raw_dependencies = dependencies
         self.dependencies = None
         self.compatibility = compatibility
-        self.tags = tags
+        self.classification = classification
 
     def calculate_dependencies(self, by_unique_id_and_md5sum):
         dependencies = []
@@ -78,7 +78,7 @@ class ContentEntry:
             f"md5sum={self.md5sum!r}, "
             f"dependencies={self.dependencies!r}, "
             f"compatibility={self.compatibility!r}, "
-            f"tags={self.tags!r})"
+            f"classification={self.classification!r})"
         )
 
 
@@ -130,7 +130,7 @@ class Index:
                 "unique-id": unique_id,
                 "md5sum": md5sum,
                 "compatibility": compatibility,
-                "tags": data.get("tags", []),
+                "classification": data.get("tagclassifications", {}),
                 "raw-dependencies": dependencies,
             }
         )
@@ -146,8 +146,14 @@ class Index:
         size += len(md5sum) + 2
         size += len(dependencies) * 4
         size += 1
-        for tag in data.get("tags", []):
-            size += len(tag) + 2
+        for key, value in data.get("classification", {}).items():
+            size += len(key) + 2
+            if type(value) == str:
+                size += len(value) + 2
+            elif type(value) == bool:
+                size += len("yes") + 2
+            else:
+                raise Exception("Invalid classification value", value)
 
         if size > 1400:
             raise Exception("Entry would exceed OpenTTD packet size.")
@@ -165,7 +171,7 @@ class Index:
             md5sum=md5sum,
             dependencies=dependencies,
             compatibility=compatibility,
-            tags=data.get("tags", []),
+            classification=data.get("classification", {}),
         )
 
         # Calculate the content-id we want to give him, but don't assign it

--- a/bananas_server/index/schema.py
+++ b/bananas_server/index/schema.py
@@ -21,7 +21,7 @@ class ContentEntry(Schema):
     version = fields.String(validate=validate.Length(max=15))
     url = fields.String(validate=validate.Length(max=95))
     description = fields.String(validate=validate.Length(max=511))
-    tags = fields.List(fields.String(validate=validate.Length(max=31)))
+    classification = fields.Dict(keys=fields.String(), values=fields.String())
     md5sum = fields.Raw(validate=validate.Length(min=16, max=16))
     compatibility = fields.Dict(
         keys=fields.String(),


### PR DESCRIPTION
This is mostly for backwards compatibility; as we no longer allow custom tags, the best-next-thing are the classification markers.

This means in current OpenTTD clients they show up as tags, in which you can search etc. This was kinda how tags were meant, but sadly people decided to use them for completely different purposes.