### PR TITLE
Change: create a new event-loop on startup, instead of assuming it exists

### DIFF
--- a/bananas_server/__main__.py
+++ b/bananas_server/__main__.py
@@ -83,7 +83,7 @@ def main(bind, content_port, web_port, storage, index, bootstrap_unique_id, vali
     if validate:
         return
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     server = loop.run_until_complete(run_server(app_instance, bind, content_port))
 
     ContentProtocol.proxy_protocol = proxy_protocol


### PR DESCRIPTION
This fixes the warning that there is no event-loop yet (but it is created for you nevertheless).