### PR TITLE
Fix: in peak times, ip-to-version-cache cycles before the 1 minute mark

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -45,7 +45,7 @@ def set_version_from_source(source, version):
     IP_TO_VERSION_CACHE[source.ip] = version
 
     # Ensure this cache doesn't grow out of control.
-    if len(IP_TO_VERSION_CACHE) > 1000:
+    if len(IP_TO_VERSION_CACHE) > 10000:
         IP_TO_VERSION_CACHE.pop(next(iter(IP_TO_VERSION_CACHE)))
 
 


### PR DESCRIPTION
The whole point of this cache is that it survives at least 1 minute, as that is how long the client can take to get back tous.