### PR TITLE
Codechange: remove dependency on marshmallow-enum

### DIFF
--- a/bananas_server/index/schema.py
+++ b/bananas_server/index/schema.py
@@ -3,7 +3,6 @@ from marshmallow import (
     Schema,
     validate,
 )
-from marshmallow_enum import EnumField
 
 from ..helpers.content_type import ContentType
 
@@ -14,7 +13,7 @@ class ContentEntry(Schema):
 
     content_id = fields.Integer(data_key="content-id")
     unique_id = fields.Raw(data_key="unique-id", validate=validate.Length(min=4, max=4))
-    content_type = EnumField(ContentType, data_key="content-type", by_value=True)
+    content_type = fields.Enum(ContentType, data_key="content-type", by_value=True)
     filesize = fields.Integer()
     # Most of these limits are limitations in the OpenTTD client.
     name = fields.String(validate=validate.Length(max=31))
@@ -36,7 +35,7 @@ class ContentEntry(Schema):
     raw_dependencies = fields.List(
         fields.Tuple(
             (
-                EnumField(ContentType, by_value=True),
+                fields.Enum(ContentType, by_value=True),
                 fields.Raw(validate=validate.Length(min=4, max=4)),
                 fields.Raw(validate=validate.Length(min=16, max=16)),
             )

--- a/requirements.base
+++ b/requirements.base
@@ -3,7 +3,6 @@ boto3
 click
 gitpython
 marshmallow
-marshmallow-enum
 openttd-helpers
 openttd-protocol
 prometheus-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ GitPython==3.1.44
 idna==3.10
 jmespath==1.0.1
 marshmallow==4.0.0
-marshmallow-enum==1.5.1
 multidict==6.5.0
 openttd-helpers==1.4.0
 openttd-protocol==1.7.1


### PR DESCRIPTION
It is now integrated in marshmallow, so also no longer a need.