### PR TITLE
Feature: Send availability in content info.

### DIFF
--- a/bananas_server/application/bananas_server.py
+++ b/bananas_server/application/bananas_server.py
@@ -103,6 +103,7 @@ class Application:
             md5sum=content_entry.md5sum,
             dependencies=content_entry.dependencies,
             tags=list(sorted(tags)),
+            availability=content_entry.availability,
         )
 
     def get_by_content_id(self, content_id):

--- a/bananas_server/helpers/availability.py
+++ b/bananas_server/helpers/availability.py
@@ -1,0 +1,10 @@
+from openttd_protocol.protocol.content import Availability
+
+
+def get_int_value_from_string_name(availability):
+    match availability:
+        case "savegames-only":
+            return Availability.AVAILABILITY_SAVEGAMES_ONLY
+        case "new-games":
+            return Availability.AVAILABILITY_NEW_GAMES
+    return Availability.AVAILABILITY_INVALID

--- a/bananas_server/index/local.py
+++ b/bananas_server/index/local.py
@@ -10,6 +10,7 @@ from openttd_protocol.protocol.content import ContentType
 from .schema import ContentEntry as ContentEntryTest
 from ..helpers.content_type import get_content_type_from_name
 from ..helpers.content_type import get_folder_name_from_content_type
+from ..helpers.availability import get_int_value_from_string_name
 
 log = logging.getLogger(__name__)
 
@@ -136,6 +137,7 @@ class Index:
                 "classification": data.get("tagclassifications", {}),
                 "regions": data.get("regions", []),
                 "raw-dependencies": dependencies,
+                "availability": get_int_value_from_string_name(data.get("availability", "")),
             }
         )
 
@@ -149,6 +151,7 @@ class Index:
         size += len(unique_id) + 2
         size += len(md5sum) + 2
         size += len(dependencies) * 4
+        size += 1  # availability
         size += 1
         for key, value in data.get("classification", {}).items():
             size += len(key) + 2
@@ -179,6 +182,7 @@ class Index:
             compatibility=compatibility,
             classification=data.get("classification", {}),
             regions=data.get("regions", []),
+            availability=get_int_value_from_string_name(data.get("availability", "")),
         )
 
         # Calculate the content-id we want to give him, but don't assign it

--- a/bananas_server/index/schema.py
+++ b/bananas_server/index/schema.py
@@ -5,6 +5,7 @@ from marshmallow import (
 )
 
 from ..helpers.content_type import ContentType
+from ..helpers.availability import Availability
 
 
 class ContentEntry(Schema):
@@ -42,3 +43,4 @@ class ContentEntry(Schema):
         ),
         data_key="raw-dependencies",
     )
+    availability = fields.Enum(Availability, data_key="availability", by_value=True)


### PR DESCRIPTION
The server part of the https://github.com/OpenTTD/py-protocol/pull/36 from py-protocol.

Converts string representation of availability which is human readable into an byte value from the enum which is light and better for TCP.